### PR TITLE
Fix tie direction

### DIFF
--- a/OPENMUSIC/code/projects/musicproject/editor/scoreeditor/rendering.lisp
+++ b/OPENMUSIC/code/projects/musicproject/editor/scoreeditor/rendering.lisp
@@ -653,14 +653,6 @@
                           (round (- right left) 2) (round (- bot top) 2) 180 major-angle 90)))
 
 
-
-
-(defmethod get-tie-direction ((self grap-note))
-   (let* ((note (midic (reference self)))
-          (list (sort (lmidic (parent (reference self))) '<)))
-     (if (>= (position note list :test 'equal) (ceiling (/ (length list) 2)))
-       "up" "down")))
-
 ;--------drawing points for rhythmic notes
 (defun write-note-points (self  x y  size )
   (om-with-font (om-make-font *om-def-font-face*  size)

--- a/OPENMUSIC/code/projects/musicproject/editor/scoreeditor/rendering.lisp
+++ b/OPENMUSIC/code/projects/musicproject/editor/scoreeditor/rendering.lisp
@@ -544,7 +544,7 @@
         (om-draw-string altpos (+ y (y self)) altstr))
       (setf (rectangle self) (list altpos (+ y (- (y self) (round size 8)))
                                    (+ realpos (round size 3)) (+ y (round size 8) (y self))))
-      (draw-note-liason note self size realpos zoom y))
+      (draw-note-liason note self size realpos zoom y staff))
     (draw-note-aux-lines self size realpos headsizex y)
     (write-note-slot self realpos (+ y (y self)) slot size zoom)
     (draw-extras self size staff)))
@@ -614,10 +614,10 @@
                   (setf topy (- topy (round size 4))))))))))
 
 ;-------drawing ties
-(defun draw-note-liason (note self size realpos zoom y)
+(defun draw-note-liason (note self size realpos zoom y staff)
   (let ((tie (tie note)))
     (when tie
-      (let* ((direction (get-tie-direction self))
+      (let* ((direction (get-tie-direction self staff))
              (toptie (if (string-equal direction "down") (+ y (y self)) (- (+ y (y self)) (round size 3))))
              (bottie (if (string-equal direction "down") (+ y (y self) (round size 3)) (+ y (y self))))
              othernote)

--- a/OPENMUSIC/code/projects/musicproject/editor/scoreeditor/scoretools.lisp
+++ b/OPENMUSIC/code/projects/musicproject/editor/scoreeditor/scoretools.lisp
@@ -817,7 +817,7 @@
       
       (setf tie (tie (reference self))) 
       (when tie
-        (let* ((direction (get-tie-direction self))
+	(let* ((direction (get-tie-direction self staff))
                (toptie (if (string-equal direction "down") (+ y (y self)) (- (+ y (y self)) (round size 3))))
                (bottie (if (string-equal direction "down") (+ y (y self) (round size 3)) (+ y (y self))))
                othernote)
@@ -859,12 +859,16 @@
                                 (+  headsizex  realpos) topy)
                   (setf topy (- topy (round size 4))))))))))
 
-(defmethod get-tie-direction ((self grap-note))
-   (let* ((note (midic (reference self)))
-          (list (sort (lmidic (parent (reference self))) '<)))
-     (if (>= (position note list :test 'equal) (ceiling (/ (length list) 2)))
-       "up" "down")))
 
+(defmethod get-tie-direction ((self grap-note) staff)
+  (let* ((note (midic (reference self)))
+         (center-note-staff (* (midicenter staff) 100))
+	 (list (sort (lmidic (parent (reference self))) '<))
+	 (note-pos (position note list :test 'equal)))
+    (cond ((= (length list) 1) (if (> note center-note-staff) "up" "down"))
+	  ((if (>= note-pos (/ (length list) 2))
+	       "up" "down" ; not quite right: if odd number of notes, then "majority away from stem"
+	       )))))
 
 (defun write-note-points (self x y  size)
   (loop for i from 1 to (points self) do


### PR DESCRIPTION
Hi Karim.  I think i've fixed a bug in drawing ties.  Single ties should point away from the stem.

Directions of ties between chords where the second chord has flipped stem is still not right.

This is still not 100% according to E. Gould, but certainly better than it was.

If odd number of ties, the majority should curve away from the stem.  This isn't always accurate with the current setup, so i'll leave that for now. 